### PR TITLE
Add truncate support to file_cache.

### DIFF
--- a/turbonfs/inc/file_cache.h
+++ b/turbonfs/inc/file_cache.h
@@ -793,7 +793,7 @@ public:
  * passed.
  *
  * Note: SCAN_ACTION_TRUNCATE is same as SCAN_ACTION_RELEASE just that
- *       safe_to_release() check is bypassed and we force release, bytes_chunk
+ *       safe_to_release() check is bypassed and we force release bytes_chunk
  *       even if they are dirty or o/w.
  */
 enum class scan_action
@@ -1055,6 +1055,10 @@ public:
      *
      * Once truncate() completes, subsequent get() call will not return
      * cache data for any byte in the truncated region.
+     *
+     * Note: Caller MUST make sure that there are no ongoing flush operations
+     *       on the file, else they can change the file size back to a higher
+     *       value.
      */
     uint64_t truncate(uint64_t length)
     {

--- a/turbonfs/src/file_cache.cpp
+++ b/turbonfs/src/file_cache.cpp
@@ -555,7 +555,10 @@ void membuf::set_truncated()
      * referring to the membuf.
      * This should only be called when file region covering "entire" membuf
      * is truncated.
+     * Once truncated the corresponding bytes_chunk must be removed from
+     * chunkmap, so future users should not get it.
      */
+    assert(!is_truncated());
     flag |= MB_Flag::Truncated;
 
     AZLogDebug("Set truncated membuf [{}, {}), fd={}",

--- a/turbonfs/src/rpc_stats.cpp
+++ b/turbonfs/src/rpc_stats.cpp
@@ -143,6 +143,10 @@ void rpc_stats_az::dump_stats()
                   " release calls\n";
     str += "  " + std::to_string(bytes_chunk_cache::bytes_release_g) +
                   " bytes released\n";
+    str += "  " + std::to_string(bytes_chunk_cache::num_truncate_g) +
+                  " truncate calls\n";
+    str += "  " + std::to_string(bytes_chunk_cache::bytes_truncate_g) +
+                  " bytes truncated\n";
 
     str += "Application statistics:\n";
     str += "  " + std::to_string(GET_GBL_STATS(tot_bytes_read)) +


### PR DESCRIPTION
Added bytes_chunk_cache::truncate(length) to let caller truncate a file cache. It should be called when the underlying file is truncated. Once truncate() completes, subsquent calls to get() will not return cached data in the truncated region.