### PR TITLE
Fix race of release vs unlink/rename

### DIFF
--- a/turbonfs/inc/nfs_client.h
+++ b/turbonfs/inc/nfs_client.h
@@ -425,6 +425,7 @@ public:
         fuse_req_t req,
         fuse_ino_t parent_ino,
         const char *name,
+        fuse_ino_t ino,
         bool for_silly_rename);
 
     void rmdir(
@@ -455,6 +456,7 @@ public:
         const char *name,
         fuse_ino_t newparent_ino,
         const char *new_name,
+        fuse_ino_t dst_ino = 0,
         bool silly_rename = false,
         fuse_ino_t silly_rename_ino = 0,
         fuse_ino_t oldparent_ino = 0,

--- a/turbonfs/inc/nfs_inode.h
+++ b/turbonfs/inc/nfs_inode.h
@@ -525,6 +525,21 @@ public:
     void truncate_end() const;
 
     /**
+     * delete_start() must be called before issuing the REMOVE/RENAME RPC
+     * and delete_end() must be called from their respective callback.
+     * delete_start() grabs the is_flushing lock to ensure no new flush/commit
+     * operations can be issued for this inode, and waits for any ongoing
+     * flush/commit operations to complete, before truncating the filecache
+     * to 0 size.
+     * delete_end() simply calls flush_unlock() to release the is_flushing
+     * lock held by delete_start().
+     * This two apis together ensure that any flush/commit operation cannot
+     * run after the file has been deleted/renamed.
+     */
+    bool delete_start();
+    void delete_end() const;
+
+    /**
      * This MUST be called only after has_filecache() returns true, else
      * there's a possibility of data race, as the returned filecache_handle
      * ref may be updated by alloc_filecache() right after get_filecache()

--- a/turbonfs/inc/rpc_task.h
+++ b/turbonfs/inc/rpc_task.h
@@ -1001,6 +1001,11 @@ struct unlink_rpc_task
         return file_name;
     }
 
+    fuse_ino_t get_ino() const
+    {
+        return ino;
+    }
+
     bool get_for_silly_rename() const
     {
         return for_silly_rename;
@@ -1016,6 +1021,11 @@ struct unlink_rpc_task
         file_name = ::strdup(name);
     }
 
+    void set_ino(fuse_ino_t _ino)
+    {
+       ino = _ino;
+    }
+
     void set_for_silly_rename(bool _for_silly_rename)
     {
         for_silly_rename = _for_silly_rename;
@@ -1029,6 +1039,12 @@ struct unlink_rpc_task
 private:
     fuse_ino_t parent_ino;
     char *file_name;
+    /*
+     * Inode being deleted.
+     * This should be set only for regular file which has filecache
+     * allocated.
+     */
+    fuse_ino_t ino;
 
     /*
      * Is this unlink task deleting a silly-renamed file when the last opencnt
@@ -1180,6 +1196,16 @@ struct rename_rpc_task
         return newparent_ino;
     }
 
+    void set_dst_ino(fuse_ino_t dst)
+    {
+        dst_ino = dst;
+    }
+
+    fuse_ino_t get_dst_ino() const
+    {
+        return dst_ino;
+    }
+
     void set_newname(const char *name)
     {
         assert(name != nullptr);
@@ -1260,6 +1286,13 @@ private:
     char *name;
     char *newname;
     char *oldname;
+    /*
+     * Inode of the destination being renamed.
+     * This should be set only for regular file which has filecache
+     * allocated.
+     */
+    fuse_ino_t dst_ino;
+
     bool silly_rename;
     fuse_ino_t silly_rename_ino;
 };
@@ -2007,6 +2040,7 @@ public:
     void init_unlink(fuse_req *request,
                      fuse_ino_t parent_ino,
                      const char *name,
+                     fuse_ino_t ino,
                      bool for_silly_rename);
 
     void run_unlink();
@@ -2070,6 +2104,7 @@ public:
                      const char *name,
                      fuse_ino_t newparent_ino,
                      const char *newname,
+                     fuse_ino_t dst_ino = 0,
                      bool silly_rename = false,
                      fuse_ino_t silly_rename_ino = 0,
                      fuse_ino_t oldparent_ino = 0,


### PR DESCRIPTION
If release() gets called on a file with dirty buffers, release() drops the opencnt and then syncs the dirty data to the backend. If an unlink/rename call happens to come at this time where opencnt=0 but the flush is still ongoing, we might endup deleting the file before the data is flushed to the backend causing writes to fail on the server. To avoid this, the unlink/rename will wait for any ongoing flush to complete before issuing a remove/rename RPC to the server.