### PR TITLE
wait_for_ongoing_flush must drain the currently running callback

### DIFF
--- a/turbonfs/inc/fcsm.h
+++ b/turbonfs/inc/fcsm.h
@@ -159,6 +159,27 @@ public:
         return inode;
     }
 
+    void fc_cb_enter()
+    {
+        ++in_fc_callback;
+    }
+
+    void fc_cb_exit()
+    {
+        assert(fc_cb_running());
+        --in_fc_callback;
+    }
+
+    uint64_t fc_cb_count() const
+    {
+        return in_fc_callback;
+    }
+
+    bool fc_cb_running() const
+    {
+        return (fc_cb_count() > 0);
+    }
+
 private:
     /*
      * The singleton nfs_client, for convenience.
@@ -251,11 +272,21 @@ private:
     std::atomic<uint64_t> flushing_seq_num = 0;
     std::atomic<uint64_t> committed_seq_num = 0;
     std::atomic<uint64_t> committing_seq_num = 0;
+    std::atomic<uint64_t> in_fc_callback = 0;
 
     /*
      * The state machine starts in an idle state.
      */
     std::atomic<bool> running = false;
+};
+
+struct FC_CB_TRACKER
+{
+    explicit FC_CB_TRACKER(struct nfs_inode *_inode);
+    ~FC_CB_TRACKER();
+
+    private:
+    struct nfs_inode *const inode;
 };
 
 }

--- a/turbonfs/src/rpc_task.cpp
+++ b/turbonfs/src/rpc_task.cpp
@@ -1015,6 +1015,7 @@ static void write_iov_callback(
     const int status = task->status(rpc_status, NFS_STATUS(res), &errstr);
     const fuse_ino_t ino = task->rpc_api->write_task.get_ino();
     struct nfs_inode *inode = client->get_nfs_inode_from_ino(ino);
+    FC_CB_TRACKER fccbt(inode);
 
     /*
      * Now that the request has completed, we can query libnfs for the
@@ -1118,7 +1119,6 @@ static void write_iov_callback(
              * write completes.
              */
             task->free_rpc_task();
-
             return;
         } else {
             // Complete bc_iovec IO completed.


### PR DESCRIPTION
else we can have a deadlock where write_iov_callback() first releases the membuf lock which make wait_for_ongoing_flush() believe that all flush are done and it can take the flush_lock safely, but write_iov_callback() calls on_flush_complete() later which grabs the flush_lock. This can cause a deadlock. The fix is to let the callback drain. Since wait_for_ongoing_flush() is a rarely used function, we make that check while write_iov_callback() can run w/o any additional check or complexity.
Another way of solving this would be to release the membuf lock after on_flush_complete() runs, but then it would have added unncessary restrictions on what we can do insode on_flush_complete().