### PR TITLE
Implement 2 phase truncate.

### DIFF
--- a/turbonfs/inc/file_cache.h
+++ b/turbonfs/inc/file_cache.h
@@ -298,8 +298,16 @@ struct membuf
     bool is_locked() const
     {
         const bool locked = (flag & MB_Flag::Locked);
+        /*
+         * XXX Following assert is usually true but for the rare case when
+         *     caller may drop the inuse count while holding the lock for
+         *     release()ing the chunk, this will not hold.
+         *     See read_callback() for such usage.
+         */
+#if 0
         // If locked, must be inuse.
         assert(is_inuse() || !locked);
+#endif
         return locked;
     }
 
@@ -410,9 +418,16 @@ struct membuf
      * right side of the membuf.
      * It'll perform necessary validations and updations needed when a membuf is
      * trimmed.
-     * Caller must own the membuf for trimming it, i.e,. membuf must be locked and
-     * in use. Called from release() and truncate(), release() can trim both from
-     * left and right while truncate_() can only trim from right.
+     * Caller must make sure that this membuf is not being accessed by some other
+     * thread. and trim() can safely update it. This means, trim() can be called
+     * in one of the following cases:
+     * 1. membuf is locked.
+     *    See bytes_chunk_cache::truncate().
+     * 2. chunkmap lock is held and membuf is not inuse.
+     *    See bytes_chunk_cache::scan()->safe_to_release().
+     *
+     * Called from release() and truncate(), release() can trim both from left
+     * and right while truncate() can only trim from right.
      */
     void trim(uint64_t trim_len, bool left);
 
@@ -587,7 +602,7 @@ public:
      * a bytes_chunk from the left and must always match membuf::offset while
      * for non-chunkmap bcs (those returned by get()/getx()) this will be the
      * copy of membuf::offset at the time the bc was created, membuf can be
-     * later trimmed and it's offset may increase.
+     * later trimmed and its offset may increase.
      */
     uint64_t offset = 0;
 
@@ -598,7 +613,7 @@ public:
      * a bytes_chunk from left and right and must always match membuf::length
      * while for non-chunkmap bcs (those returned by get()/getx()) this will be
      * the copy of membuf::length at the time the bc was created, membuf can be
-     * later trimmed and it's length may reduce.
+     * later trimmed and its length may reduce.
      */
     uint64_t length = 0;
 
@@ -751,19 +766,19 @@ public:
      *   maybe it's writing fresh data to it and may mark it dirty. If we
      *   allow such membuf to be released, future readers who get() the cache
      *   will miss those changes.
-     *   We check for inuse==1 as the caller releasing the membuf must be owning
-     *   the membuf and it must be the only one owning it.
      * - commit pending means those membufs are sitting in the TBL of the Blob,
      *   not yet committed, server may fail the commit in which case we might
      *   have to resend those to the server and hence we cannot free those
      *   till successful commit.
+     *
+     * Note: Since we do not allow inuse membufs to be released, it means
+     *       if caller is owning the membuf they must drop their inuse count
+     *       before calling release().
      */
     bool safe_to_release() const
     {
         const struct membuf *mb = get_membuf();
-        return (mb->get_inuse() == 1) &&
-               !mb->is_dirty() &&
-               !mb->is_commit_pending();
+        return !mb->is_inuse() && !mb->is_dirty() && !mb->is_commit_pending();
     }
 
     /**
@@ -1123,10 +1138,8 @@ public:
      * release and cannot mark uptodate.
      *
      * Note: For releasing all chunks and effectively nuking the cache, use
-     *       clear(), but note that clear() also won't release "inuse" chunks.
-     *
-     * Note: You MUST only call release() for membuf that you own, i.e., it's
-     *       inuse and locked by you.
+     *       clear(), but note that clear() also won't release above chunks,
+     *       for which safe_to_release() returns false.
      */
     uint64_t release(uint64_t offset, uint64_t length)
     {

--- a/turbonfs/inc/file_cache.h
+++ b/turbonfs/inc/file_cache.h
@@ -176,15 +176,21 @@ struct membuf
 
     /*
      * This membuf caches file data in the range [offset, offset+length).
-     * These are initialized in the constructor and not changed thereafter.
-     * If user trims the cache, the corresponding chunkmap[]'s offset, length
-     * and buffer_offset are updated accordingly, but the underlying membuf
-     * fields are not changed. This is IMPORTANT as some other bytes_chunk
-     * that we may have returned in the past may be referring to those membufs
-     * and changing those will confuse those users.
+     * A membuf starts caching [initial_offset, initial_offset+initial_length),
+     * but can be later trimmed to cache a smaller section of the file,
+     * [offset, offset+length) as some release() call releases part of the
+     * chunk. For trimming from right, only length needs to be reduced, while
+     * for trimming from left, length is reduced and offset is increased.
+     * The corresponding chunkmap[]'s offset, length and buffer_offset are also
+     * updated accordingly and they should always be same as that of the membuf.
+     *
+     * initial_offset and initial_length hold the initial values that membuf
+     * was created with, these remain unchanged for the life of the membuf.
      */
-    const uint64_t offset;
-    const uint64_t length;
+    const uint64_t initial_offset;
+    const uint64_t initial_length;
+    std::atomic<uint64_t> offset;
+    std::atomic<uint64_t> length;
 
     /*
      * Actual allocated length. This can be greater than length for
@@ -213,6 +219,10 @@ struct membuf
      *
      * Once set buffer and allocated_buffer should not change. For file-backed
      * caches drop() will munmap() and set allocated_buffer to nullptr.
+     *
+     * TODO: trim() doesn't update buffer, which means membuf::buffer does not
+     *       point to the correct data cached by this membuf. Always use
+     *       bytes_chunk::get_buffer() to get the correct address.
      */
     uint8_t *buffer = nullptr;
     uint8_t *allocated_buffer = nullptr;
@@ -402,6 +412,22 @@ struct membuf
     void set_inuse();
     void clear_inuse();
 
+    /**
+     * trim 'trim_len' bytes from the membuf. 'left' should be true if trimming
+     * is done from the left side of the membuf, else trimming is done from the
+     * right side of the membuf.
+     * It'll perform necessary validations and updations needed when a membuf is
+     * trimmed.
+     * Caller must make sure that this membuf is not being accessed by some other
+     * thread. and trim() can safely update it. This means, trim() can be called
+     * in one of the following cases:
+     * 1. membuf is locked.
+     *    See bytes_chunk_cache::truncate().
+     * 2. chunkmap lock is held and membuf is not inuse.
+     *    See bytes_chunk_cache::scan()->safe_to_release().
+     */
+    void trim(uint64_t trim_len, bool left);
+
 private:
     /*
      * Lock to correctly read and update the membuf state.
@@ -578,7 +604,7 @@ public:
      * Length of this chunk.
      * User can safely access [get_buffer(), get_buffer()+length).
      * For bytes_chunks stored in chunkmap[] this will be reduced to trim
-     * a bytes_chunk from the right.
+     * a bytes_chunk from left and right.
      */
     uint64_t length = 0;
 
@@ -694,7 +720,17 @@ public:
     {
         // Should not call on a dropped cache.
         assert(alloc_buffer->get() != nullptr);
-        assert(buffer_offset < alloc_buffer->length);
+
+        /*
+         * buffer_offset should point to a valid membuf byte.
+         * Note that this bytes_chunk is a snapshot of the chunkmap's
+         * bytes_chunk at some point in the past, after that user may have
+         * release()d the chunk which would cause membuf to be trimmed, so
+         * we cannot safely compare with the current membuf length and
+         * offset fields, but one thing we can say for sure is that
+         * buffer_offset should not exceed the membuf's initial_length.
+         */
+        assert(buffer_offset < alloc_buffer->initial_length);
 
         return alloc_buffer->get() + buffer_offset;
     }
@@ -859,17 +895,12 @@ public:
 /**
  * bytes_chunk_cache::scan() can behave differently depending on the scan_action
  * passed.
- *
- * Note: SCAN_ACTION_TRUNCATE is same as SCAN_ACTION_RELEASE just that
- *       safe_to_release() check is bypassed and we force release bytes_chunk
- *       even if they are dirty or o/w.
  */
 enum class scan_action
 {
     SCAN_ACTION_INVALID = 0,
     SCAN_ACTION_GET,
     SCAN_ACTION_RELEASE,
-    SCAN_ACTION_TRUNCATE,
 };
 
 /**
@@ -1116,59 +1147,29 @@ public:
     }
 
     /**
-     * Truncate the cache to not exceed 'length' bytes.
-     * Any bytes_chunk beyond 'length' will be:
-     * - Removed fully, if all their bytes are truncated.
-     * - Trimmed, if some of their bytes are still valid after truncate.
+     * Truncate cache to 'trunc_len' bytes.
+     * Any cached byte(s) with offset >= 'trunc_len' will be removed from the
+     * cache. All fully truncated bcs (having bc.offset >= 'trunc_len') will be
+     * removed from chunkmap. Note that 'trunc_len' can fall inside a bc, such
+     * partially truncated bc will be trimmed from the right to remove any bytes
+     * after 'trunc_len'.
+     * There are two ways to call truncate(), with 'post' as false or true.
+     * If 'post' is false, it'll lock all the affected bcs, so it may need to wait
+     * for ongoing IOs on those membufs to complete, hence it can take a long time
+     * depending on how many bytes_chunk are affected by truncate and if there are
+     * IOs ongoing on those. If 'post' is false then it calls membuf::try_lock()
+     * and skips truncating the membufs which it could not lock.
+     * Caller will typically call with post=false once at the beginning from a
+     * context that can afford to wait, make sure through external means that no
+     * new data is added to the cache, and then finally call once with post=true
+     * to cleanup anything that was added after the prev call.
      *
-     * Once truncate() completes, subsequent get() call will not return
-     * cached data for any byte in the truncated region.
-     *
-     * Note: truncate() can update one or more bytes_chunk in chunkmap while
-     *       there are users who may be using the bytes_chunk they got by a
-     *       prior call to scan()/get()/getx(). This is because truncate(),
-     *       unlike release(), does not do the safe_to_release() check.
-     *       The update may include dropping chunkmap's reference (users who
-     *       got a prior reference can still safely use their bytes_chunk) or
-     *       shrinking the bytes_chunk. Since it's the bytes_chunk that is
-     *       shrunk and not the membuf, users who have prior references to
-     *       these bytes_chunk will not note the difference. They can safely
-     *       read and write the membuf but all of the data may not be part of
-     *       the file cache.
-     *       If truncate() only drops or shrinks membufs, then it cannot cause
-     *       data consistency issues when an existing reader reads into such
-     *       a bytes_chunk and marks it uptodate, as the new partial bytes_chunk
-     *       will also be uptodate. For the writers, who have done a get()
-     *       before the truncate that removed or shrunk some of the bytes_chunk
-     *       from the chunkmap, if they later copy to those bytes_chunk, that
-     *       data would not be written to the file as that data will not be
-     *       returned by get_dirty_bc_range().
-     *
-     * Note: Caller MUST make sure that there are no ongoing flush operations
-     *       on the file, else they can change the file size back to a higher
-     *       value.
-     *
-     * Note: We can have two typical usages of truncate():
-     *       1. Truncate done by local application.
-     *       2. Truncate the cache when postop attrs carry a size
-     *          smaller than attr.st_size.
+     * Note: Since truncate() does not return with the chunkmap lock held, a
+     *       get() call done right after truncate() returns can add new data to
+     *       the truncated region. Caller should make sure through some other
+     *       means that new data is not added.
      */
-    uint64_t truncate(uint64_t length)
-    {
-        uint64_t bytes_truncated;
-
-        num_truncate++;
-        num_truncate_g++;
-
-        scan(length, AZNFSC_MAX_FILE_SIZE-length,
-             scan_action::SCAN_ACTION_TRUNCATE, &bytes_truncated);
-        assert(bytes_truncated <= (AZNFSC_MAX_FILE_SIZE-length));
-
-        bytes_truncate += bytes_truncated;
-        bytes_truncate_g += bytes_truncated;
-
-        return bytes_truncated;
-    }
+    uint64_t truncate(uint64_t trunc_len, bool post = false);
 
     /*
      * Returns all dirty chunks for a given range in chunkmap.

--- a/turbonfs/inc/fs-handler.h
+++ b/turbonfs/inc/fs-handler.h
@@ -385,6 +385,16 @@ static void aznfsc_ll_open(fuse_req_t req,
      * Mostly it'll be allocated in nfs_client::reply_entry(), but for inodes
      * conveyed through readdirplus, nfs_client::reply_entry() won't be called
      * and filecache_handle won't be allocated when aznfsc_ll_open() is called.
+     *
+     * TODO: If nocto option is not set then we should provide cto consistency,
+     *       by making a fresh getattr call to the server and if it returns
+     *       that file data has changed (mtime and/or size has changed), then
+     *       we should invalidate the cache before proceeding with open.
+     *       Cache invalidation should flush all dirty mappings before marking
+     *       cache as invalid.
+     *       If the cache is already marked invalid (see invalidate() method of
+     *       bytes_chunk_cache) then also we should flush all dirty mappings
+     *       before proceeding with the open.
      */
     inode->on_fuse_open(FUSE_OPEN);
     assert(inode->opencnt > 0);

--- a/turbonfs/inc/nfs_inode.h
+++ b/turbonfs/inc/nfs_inode.h
@@ -526,13 +526,14 @@ public:
      * operations can be issued for this inode, and waits for any ongoing
      * flush/commit operations to complete, before truncating the filecache to
      * the new size.
-     * truncate_end() simply calls flush_unlock() to release the is_flushing
-     * lock held by truncate_start().
+     * truncate_end() calls bytes_chunk_cache::truncate(post=true) to finish
+     * cache truncate and calls flush_unlock() to release the flush_lock
+     * held by truncate_start().
      * This two apis together ensure that any flush/commit operation cannot
      * change the file size after truncate sets it.
      */
     bool truncate_start(size_t size);
-    void truncate_end() const;
+    void truncate_end(size_t size) const;
 
     /**
      * This MUST be called only after has_filecache() returns true, else

--- a/turbonfs/src/file_cache.cpp
+++ b/turbonfs/src/file_cache.cpp
@@ -54,8 +54,10 @@ membuf::membuf(bytes_chunk_cache *_bcc,
                uint64_t _length,
                int _backing_file_fd) :
                bcc(_bcc),
-               offset(_offset),
-               length(_length),
+               initial_offset(_offset),
+               initial_length(_length),
+               offset(initial_offset),
+               length(initial_length),
                backing_file_fd(_backing_file_fd)
 {
     if (is_file_backed()) {
@@ -69,9 +71,10 @@ membuf::membuf(bytes_chunk_cache *_bcc,
         assert(bcc->bytes_allocated >= allocated_length);
         assert(bcc->bytes_allocated_g >= allocated_length);
     } else {
+        assert(initial_length > 0);
         // TODO: Handle memory alloc failures gracefully.
-        allocated_buffer = buffer = new uint8_t[length];
-        allocated_length = length;
+        allocated_buffer = buffer = new uint8_t[initial_length];
+        allocated_length = initial_length;
 
         bcc->bytes_allocated_g += allocated_length;
         bcc->bytes_allocated += allocated_length;
@@ -91,6 +94,21 @@ membuf::~membuf()
     assert(!is_inuse());
 
     /*
+     * Trimming can reduce length and/or increase offset, but should not
+     * make it 0. If it becomes 0, then we destroy the membuf w/o updating
+     * length/offset.
+     */
+    assert(length > 0);
+    assert(length <= initial_length);
+    assert(offset >= initial_offset);
+
+    /*
+     * length can be reduced by both left and right trimming, while offset
+     * can only be increased by left trimming.
+     */
+    assert((initial_length - length) >= (offset - initial_offset));
+
+    /*
      * dirty membuf must not be destroyed, unless it's due to file being
      * truncated, in which case we don't care about losing the unflushed
      * data.
@@ -108,7 +126,7 @@ membuf::~membuf()
              */
             assert(((uint64_t) allocated_buffer & (PAGE_SIZE - 1)) == 0);
             assert(buffer < (allocated_buffer + PAGE_SIZE));
-            assert(allocated_length >= length);
+            assert(allocated_length >= initial_length);
 
             drop();
 
@@ -118,7 +136,7 @@ membuf::~membuf()
         // Non file-backed membufs must always have a valid buffer.
         assert(allocated_buffer != nullptr);
         assert(buffer == allocated_buffer);
-        assert(length == allocated_length);
+        assert(initial_length == allocated_length);
 
         /*
          * If this is a truncated dirty membuf, we need to update the dirty
@@ -129,10 +147,17 @@ membuf::~membuf()
          */
         if (is_truncated() && is_dirty()) {
             assert(!is_flushing());
-            assert(bcc->bytes_dirty >= allocated_length);
-            assert(bcc->bytes_dirty_g >= allocated_length);
-            bcc->bytes_dirty -= allocated_length;
-            bcc->bytes_dirty_g -= allocated_length;
+            assert(bcc->bytes_dirty >= length);
+            assert(bcc->bytes_dirty_g >= length);
+            bcc->bytes_dirty -= length;
+            bcc->bytes_dirty_g -= length;
+        }
+
+        if (is_uptodate()) {
+            assert(bcc->bytes_uptodate >= length);
+            assert(bcc->bytes_uptodate_g >= length);
+            bcc->bytes_uptodate -= length;
+            bcc->bytes_uptodate_g -= length;
         }
 
         assert(bcc->bytes_allocated >= allocated_length);
@@ -146,6 +171,62 @@ membuf::~membuf()
     }
 
     assert(!allocated_buffer);
+}
+
+/**
+ * Caller must call trim() only when membuf is not owned by any other thread.
+ */
+void membuf::trim(uint64_t trim_len, bool left)
+{
+    // Can't trim more than the current size.
+    assert(trim_len > 0);
+    assert(trim_len <= length);
+
+    length -= trim_len;
+
+    if (left) {
+        offset += trim_len;
+        /*
+         * TODO: We should update membuf::buffer as well, but for now we don't
+         *       do that and it's ok as all callers access the buffer via
+         *       bytes_chunk::get_buffer().
+         */
+    }
+
+    /*
+     * Cannot safely trim a membuf that's
+     * - in use by some other thread.
+     * - flushing in progress.
+     * - commit pending.
+     *
+     * Note that we need to allow locked membufs to be trimmed. Most callers
+     * call release() with membuf lock still held.
+     *
+     * We don't want to surprise the user.
+     *
+     * Note that bytes_chunk_cache::truncate() owns the membuf when it calls
+     * trim() but it releases the lock and inuse count before calling trim().
+     * Since it's holding the chunkmap lock, no other thread can get ref on
+     * the membuf.
+     */
+    assert(!is_inuse());
+    //assert(!is_locked());
+    assert(!is_flushing());
+    assert(!is_commit_pending());
+
+    if (is_uptodate()) {
+        assert(bcc->bytes_uptodate >= trim_len);
+        assert(bcc->bytes_uptodate_g >= trim_len);
+        bcc->bytes_uptodate -= trim_len;
+        bcc->bytes_uptodate_g -= trim_len;
+    }
+
+    if (is_dirty()) {
+        assert(bcc->bytes_dirty >= trim_len);
+        assert(bcc->bytes_dirty_g >= trim_len);
+        bcc->bytes_dirty -= trim_len;
+        bcc->bytes_dirty_g -= trim_len;
+    }
 }
 
 int64_t membuf::drop()
@@ -231,20 +312,20 @@ bool membuf::load()
 
 #if 0
     // Caller must have ensured this.
-    assert(bcc->backing_file_len >= (offset + length));
+    assert(bcc->backing_file_len >= (initial_offset + initial_length));
 #endif
 
     // mmap() allows only 4k aligned offsets.
-    const uint64_t adjusted_offset = offset & ~(PAGE_SIZE - 1);
+    const uint64_t adjusted_offset = initial_offset & ~(PAGE_SIZE - 1);
 
     /*
      * First time around allocated_length would be 0, after that it must be
      * set to correct value.
      */
     assert((allocated_length == 0) ||
-           (allocated_length == (length + (offset - adjusted_offset))));
+           (allocated_length == (initial_length + (initial_offset - adjusted_offset))));
 
-    allocated_length = length + (offset - adjusted_offset);
+    allocated_length = initial_length + (initial_offset - adjusted_offset);
 
     AZLogDebug("mmap(fd={}, length={}, offset={})",
                backing_file_fd, allocated_length, adjusted_offset);
@@ -253,7 +334,7 @@ bool membuf::load()
      * Default value of /proc/sys/vm/max_map_count may not be sufficient
      * for large files. Need to increase it.
      */
-    assert(adjusted_offset <= offset);
+    assert(adjusted_offset <= initial_offset);
     allocated_buffer =
         (uint8_t *) ::mmap(nullptr,
                            allocated_length,
@@ -264,13 +345,13 @@ bool membuf::load()
 
     if (allocated_buffer == MAP_FAILED) {
         AZLogError("mmap(fd={}, length={}, offset={}) failed: {}",
-                   backing_file_fd, length, adjusted_offset,
+                   backing_file_fd, initial_length, adjusted_offset,
                    strerror(errno));
         assert(0);
         return false;
     }
 
-    buffer = allocated_buffer + (offset - adjusted_offset);
+    buffer = allocated_buffer + (initial_offset - adjusted_offset);
 
     bcc->bytes_allocated_g += allocated_length;
     bcc->bytes_allocated += allocated_length;
@@ -312,7 +393,7 @@ void membuf::set_uptodate()
         assert(bcc->bytes_uptodate <= AZNFSC_MAX_FILE_SIZE);
 
         AZLogDebug("Set uptodate membuf [{}, {}), fd={}",
-                   offset, offset+length, backing_file_fd);
+                   offset.load(), offset.load()+length.load(), backing_file_fd);
     }
 }
 
@@ -335,7 +416,7 @@ void membuf::clear_uptodate()
     bcc->bytes_uptodate_g -= length;
 
     AZLogWarn("Clear uptodate membuf [{}, {}), fd={}",
-              offset, offset+length, backing_file_fd);
+              offset.load(), offset.load()+length.load(), backing_file_fd);
 
     /*
      * Let's assert in debug builds so that we know if it happens.
@@ -373,7 +454,7 @@ void membuf::set_commit_pending()
     assert(bcc->bytes_commit_pending <= AZNFSC_MAX_FILE_SIZE);
 
     AZLogDebug("Set commit pending membuf [{}, {}), fd={}",
-               offset, offset+length, backing_file_fd);
+               offset.load(), offset.load()+length.load(), backing_file_fd);
 }
 
 /**
@@ -414,7 +495,7 @@ void membuf::clear_commit_pending()
     bcc->bytes_commit_pending_g -= length;
 
     AZLogDebug("Clear commit pending membuf [{}, {}), fd={}",
-               offset, offset+length, backing_file_fd);
+               offset.load(), offset.load()+length.load(), backing_file_fd);
 }
 
 
@@ -466,7 +547,7 @@ void membuf::set_flushing()
     assert(bcc->bytes_flushing <= AZNFSC_MAX_FILE_SIZE);
 
     AZLogDebug("Set flushing membuf [{}, {}), fd={}",
-               offset, offset+length, backing_file_fd);
+               offset.load(), offset.load()+length.load(), backing_file_fd);
 }
 
 /**
@@ -507,7 +588,7 @@ void membuf::clear_flushing()
     bcc->bytes_flushing_g -= length;
 
     AZLogDebug("Clear flushing membuf [{}, {}), fd={}",
-               offset, offset+length, backing_file_fd);
+               offset.load(), offset.load()+length.load(), backing_file_fd);
 }
 
 /**
@@ -546,13 +627,13 @@ void membuf::set_locked()
     if (inject_error()) {
         const uint64_t sleep_usecs = random_number(10'000, 1000'000);
         AZLogWarn("set_locked() membuf [{}, {}), delaying {} usecs",
-                  offset, offset+length, sleep_usecs);
+                  offset.load(), offset.load()+length.load(), sleep_usecs);
         ::usleep(sleep_usecs);
     }
 #endif
 
     AZLogDebug("Locking membuf [{}, {}), fd={}",
-               offset, offset+length, backing_file_fd);
+               offset.load(), offset.load()+length.load(), backing_file_fd);
 
     /*
      * get() returns with inuse set on the returned membufs.
@@ -594,7 +675,7 @@ void membuf::set_locked()
     bcc->num_locked_g++;
 
     AZLogDebug("Successfully locked membuf [{}, {}), fd={}",
-               offset, offset+length, backing_file_fd);
+               offset.load(), offset.load()+length.load(), backing_file_fd);
 
     // Must never return w/o locking the membuf.
     assert(is_locked());
@@ -622,7 +703,7 @@ void membuf::clear_locked()
         flag &= ~MB_Flag::Locked;
 
         AZLogDebug("Unlocked membuf [{}, {}), fd={}",
-                   offset, offset+length, backing_file_fd);
+                   offset.load(), offset.load()+length.load(), backing_file_fd);
     }
 
     assert(bcc->bytes_locked >= length);
@@ -672,7 +753,7 @@ void membuf::set_dirty()
     assert(bcc->bytes_dirty <= AZNFSC_MAX_FILE_SIZE);
 
     AZLogDebug("Set dirty membuf [{}, {}), fd={}",
-               offset, offset+length, backing_file_fd);
+               offset.load(), offset.load()+length.load(), backing_file_fd);
 }
 
 void membuf::clear_dirty()
@@ -695,7 +776,7 @@ void membuf::clear_dirty()
     bcc->bytes_dirty_g -= length;
 
     AZLogDebug("Clear dirty membuf [{}, {}), fd={}",
-               offset, offset+length, backing_file_fd);
+               offset.load(), offset.load()+length.load(), backing_file_fd);
 }
 
 void membuf::set_truncated()
@@ -719,7 +800,7 @@ void membuf::set_truncated()
     flag |= MB_Flag::Truncated;
 
     AZLogDebug("Set truncated membuf [{}, {}), fd={}",
-               offset, offset+length, backing_file_fd);
+               offset.load(), offset.load()+length.load(), backing_file_fd);
 }
 
 void membuf::set_inuse()
@@ -730,7 +811,7 @@ void membuf::set_inuse()
     inuse++;
 
     AZLogDebug("Setting inuse membuf [{}, {}), fd={}, new inuse count: {}",
-               offset, offset+length, backing_file_fd, inuse.load());
+               offset.load(), offset.load()+length.load(), backing_file_fd, inuse.load());
 }
 
 void membuf::clear_inuse()
@@ -749,7 +830,7 @@ void membuf::clear_inuse()
     inuse--;
 
     AZLogDebug("Clearing inuse membuf [{}, {}), fd={}, new inuse count: {}",
-               offset, offset+length, backing_file_fd, inuse.load());
+               offset.load(), offset.load()+length.load(), backing_file_fd, inuse.load());
 }
 
 bytes_chunk::bytes_chunk(bytes_chunk_cache *_bcc,
@@ -790,6 +871,9 @@ bytes_chunk::bytes_chunk(bytes_chunk_cache *_bcc,
     // alloc_buffer must always be valid.
     assert(alloc_buffer != nullptr);
     assert(alloc_buffer.use_count() > 1);
+    assert(alloc_buffer->offset >= alloc_buffer->initial_offset);
+    assert(alloc_buffer->length <= alloc_buffer->initial_length);
+
     /*
      * By the time bytes_chunk constructor is called
      * bytes_chunk_cache::scan() MUST have opened the backing file.
@@ -799,7 +883,13 @@ bytes_chunk::bytes_chunk(bytes_chunk_cache *_bcc,
     // 0-sized chunks don't exist.
     assert(length > 0);
     assert(length <= alloc_buffer->length);
-    assert((buffer_offset + length) <= alloc_buffer->length);
+
+    // bc must only refer to valid part of membuf.
+    assert(buffer_offset >= (alloc_buffer->offset -
+                             alloc_buffer->initial_offset));
+    assert((buffer_offset + length) <= (alloc_buffer->offset +
+                                        alloc_buffer->length -
+                                        alloc_buffer->initial_offset));
     assert(alloc_buffer->length <= AZNFSC_MAX_CHUNK_SIZE);
     assert((offset + length) <= AZNFSC_MAX_FILE_SIZE);
 
@@ -863,16 +953,6 @@ std::vector<bytes_chunk> bytes_chunk_cache::scan(uint64_t offset,
         ::usleep(sleep_usecs);
     }
 #endif
-
-    /*
-     * We need to perform the same action for both release and truncate, just
-     * that truncate is always allowed while release is allowed only if
-     * safe_to_release() returns true.
-     */
-    const bool do_truncate = (action == scan_action::SCAN_ACTION_TRUNCATE);
-    if (do_truncate) {
-        action = scan_action::SCAN_ACTION_RELEASE;
-    }
 
     assert(offset < AZNFSC_MAX_FILE_SIZE);
     assert(length > 0);
@@ -1318,6 +1398,10 @@ do { \
     for (; remaining_length != 0 && it != chunkmap.end(); ) {
         bc = &(it->second);
 
+        // membuf and bc offset and length must always be in sync.
+        assert(bc->length == bc->get_membuf()->length);
+        assert(bc->offset == bc->get_membuf()->offset);
+
         /*
          * For the GET and file-backed cache, make sure the requested chunk is
          * duly mmapped so that any IO that caller performs on the returned
@@ -1358,8 +1442,8 @@ do { \
                              chunk_offset, chunk_offset + chunk_length,
                              fmt::ptr(chunkvec.back().get_buffer()),
                              fmt::ptr(bc->alloc_buffer->get()));
-            } else if (do_truncate || bc->safe_to_release()) {
-                assert (action == scan_action::SCAN_ACTION_RELEASE);
+            } else if (bc->safe_to_release()) {
+                assert(action == scan_action::SCAN_ACTION_RELEASE);
 
                 /*
                  * chunk_length bytes will be released.
@@ -1375,10 +1459,10 @@ do { \
                     AZLogVerbose("<Release [{}, {})> (releasing chunk) [{},{}) "
                                  "b:{} a:{}",
                                  offset, offset + length,
-                               chunk_offset, chunk_offset + chunk_length,
-                               bc->alloc_buffer->get() ?
-                                    fmt::ptr(bc->get_buffer()) : nullptr,
-                               fmt::ptr(bc->alloc_buffer->get()));
+                                 chunk_offset, chunk_offset + chunk_length,
+                                 bc->alloc_buffer->get() ?
+                                        fmt::ptr(bc->get_buffer()) : nullptr,
+                                 fmt::ptr(bc->alloc_buffer->get()));
                     /*
                      * Queue the chunk for deletion, since the entire chunk is
                      * released.
@@ -1405,9 +1489,13 @@ do { \
                                  bc->offset + chunk_length,
                                  bc->offset + bc->length);
 
+                    // Trim chunkmap bc.
                     bc->offset += chunk_length;
                     bc->buffer_offset += chunk_length;
                     bc->length -= chunk_length;
+
+                    // Trim membuf.
+                    bc->get_membuf()->trim(chunk_length, true /* left */);
 
                     /*
                      * Don't update num_chunks/num_chunks_g as we remove one
@@ -1519,7 +1607,7 @@ do { \
                              chunk_offset, chunk_offset + chunk_length,
                              fmt::ptr(chunkvec.back().get_buffer()),
                              fmt::ptr(bc->alloc_buffer->get()));
-            } else if (do_truncate || bc->safe_to_release()) {
+            } else if (bc->safe_to_release()) {
                 assert(action == scan_action::SCAN_ACTION_RELEASE);
                 assert(chunk_length <= remaining_length);
 
@@ -1564,8 +1652,12 @@ do { \
                                  bc->offset, bc->offset + bc->length,
                                  bc->offset, next_offset);
 
+                    // Trim chunkmap bc.
                     bc->length = next_offset - bc->offset;
                     assert((int64_t) bc->length > 0);
+
+                    // Trim membuf.
+                    bc->get_membuf()->trim(chunk_length, false /* left */);
 
                     assert(bytes_cached >= trim_bytes);
                     assert(bytes_cached_g >= trim_bytes);
@@ -1594,8 +1686,8 @@ do { \
                              "to release: inuse={}, dirty={}",
                              offset, offset + length,
                              chunk_offset, chunk_offset + chunk_length,
-                           bc->get_membuf()->get_inuse(),
-                           bc->get_membuf()->is_dirty());
+                             bc->get_membuf()->get_inuse(),
+                             bc->get_membuf()->is_dirty());
             }
 
             // This chunk is fully consumed, move to the next chunk.
@@ -1772,7 +1864,7 @@ allocate_only_chunk:
                  * Not all chunks from begin_delete to end_delete are
                  * guaranteed safe-to-delete, so check before deleting.
                  */
-                if (do_truncate || bc->safe_to_release()) {
+                if (bc->safe_to_release()) {
                     AZLogVerbose("<Release [{}, {})> (freeing chunk) [{},{}) "
                                  "b:{} a:{}",
                                  offset, offset + length,
@@ -1793,9 +1885,6 @@ allocate_only_chunk:
 
                     bytes_released_tmp += bc->length;
 
-                    if (do_truncate) {
-                        bc->get_membuf()->set_truncated();
-                    }
                     chunkmap.erase(_it);
                 }
             }
@@ -1869,6 +1958,187 @@ end:
                 ? chunkvec : std::vector<bytes_chunk>();
 }
 
+uint64_t bytes_chunk_cache::truncate(uint64_t trunc_len, bool post)
+{
+    assert(trunc_len <= AZNFSC_MAX_FILE_SIZE);
+
+    /*
+     * Count of how many bytes we drop from the cache, to serve this truncate
+     * request. We return this to the caller.
+     */
+    uint64_t bytes_truncated = 0;
+
+    /*
+     * Step #1: Grab chunkmap lock and mark all the affected bcs inuse, so that
+     *          they aren't removed while we work on them in subsequent steps.
+     */
+    std::vector<std::map<uint64_t, struct bytes_chunk>::iterator> it_vec1;
+    {
+        // TODO: Make it shared lock.
+        const std::unique_lock<std::mutex> _lock(chunkmap_lock_43);
+
+        if (chunkmap.empty()) {
+            return 0;
+        }
+
+        /*
+         * Get chunk with starting offset >= trunc_len.
+         * If prev bc has one or more bytes to be truncated, count that in too.
+         */
+        auto it = chunkmap.lower_bound(trunc_len);
+
+        if (it != chunkmap.begin()) {
+            auto prev_it = std::prev(it);
+            const struct bytes_chunk *prev_bc = &(prev_it->second);
+
+            assert(trunc_len > prev_bc->offset);
+
+            if (trunc_len < (prev_bc->offset + prev_bc->length)) {
+                // Prev bc has one or more bytes truncated.
+                it = prev_it;
+            }
+        }
+
+        /*
+         * Add iterators to all the affected bcs in it_vec1.
+         * Note that since we don't remove an inuse bc from the chunkmap, it's
+         * safe to access these iterators after the chunkmap lock is released.
+         */
+        while (it != chunkmap.cend()) {
+            const struct bytes_chunk& bc = it->second;
+            struct membuf *mb = bc.get_membuf();
+
+            // bc must have at least one byte truncated.
+            assert((bc.offset + bc.length) > trunc_len);
+
+            mb->set_inuse();
+            it_vec1.emplace_back(it);
+
+            ++it;
+        }
+    }
+
+    /*
+     * Step #2: Grab membuf lock for all the affected bcs.
+     *          Once we have all the locks, we are guaranteed that no IOs are
+     *          ongoing on any of the truncated bcs and no new IOs can be
+     *          started.
+     */
+    std::vector<std::map<uint64_t, struct bytes_chunk>::iterator> it_vec3;
+    for (auto &it : it_vec1) {
+        const struct bytes_chunk& bc = it->second;
+        struct membuf *mb = bc.get_membuf();
+
+        assert(mb != nullptr);
+        // We grabbed it above.
+        assert(mb->is_inuse());
+
+        /*
+         * For all bcs that we could get the membuf lock, add them to it_vec3.
+         * These will be truncated (fully or partially).
+         * If post is true we use try_lock() and skip if we do not get the lock.
+         */
+        if (post) {
+            if (mb->try_lock()) {
+                it_vec3.emplace_back(it);
+            }
+        } else {
+            mb->set_locked();
+            it_vec3.emplace_back(it);
+        }
+    }
+
+    assert(it_vec3.size() <= it_vec1.size());
+
+    /*
+     * Step #3: Release all the affected bcs. If there's a partial bc, it'll be
+     *          trimmed from the right.
+     */
+    {
+        const std::unique_lock<std::mutex> _lock(chunkmap_lock_43);
+
+        for (auto& it : it_vec3) {
+            struct bytes_chunk& bc = it->second;
+            struct membuf *mb = bc.get_membuf();
+
+            // membuf and bc offset and length must always be in sync.
+            assert(bc.length == mb->length);
+            assert(bc.offset == mb->offset);
+
+            /*
+             * Clear these as we don't want to trim or destroy an inuse membuf.
+             * It's safe as we have the chunkmap lock.
+             */
+            mb->clear_locked();
+            mb->clear_inuse();
+
+            /*
+             * it_vec3 should not have any bc that lies completely before
+             * trunc_len.
+             */
+            assert((bc.offset + bc.length) > trunc_len);
+
+            // trunc_len falls inside this bc?
+            if (bc.offset < trunc_len) {
+                // How many bytes to trim from the right?
+                const uint64_t trim_bytes = (bc.offset + bc.length - trunc_len);
+                assert(trim_bytes > 0);
+
+                AZLogVerbose("<Truncate {}> (trimming chunk from right) "
+                             "[{},{}) -> [{},{})",
+                             trunc_len,
+                             bc->offset, bc->offset + bc->length,
+                             bc->offset, trunc_len);
+
+                // Trim chunkmap bc.
+                bc.length -= trim_bytes;
+                assert((int64_t) bc.length > 0);
+
+                // Trim membuf.
+                mb->trim(trim_bytes, false /* left */);
+
+                assert(bytes_cached >= trim_bytes);
+                assert(bytes_cached_g >= trim_bytes);
+                bytes_cached -= trim_bytes;
+                bytes_cached_g -= trim_bytes;
+
+                bytes_truncated += trim_bytes;
+            } else {
+                /*
+                 * Release the chunk.
+                 * This will release the membuf (munmap() it in case of file-backed
+                 * cache and delete it for heap backed cache).
+                 */
+                assert(num_chunks > 0);
+                num_chunks--;
+                assert(num_chunks_g > 0);
+                num_chunks_g--;
+
+                assert(bytes_cached >= bc.length);
+                assert(bytes_cached_g >= bc.length);
+                bytes_cached -= bc.length;
+                bytes_cached_g -= bc.length;
+
+                bytes_truncated += bc.length;
+
+                mb->set_truncated();
+                chunkmap.erase(it);
+            }
+        }
+    }
+
+    assert(bytes_truncated <= (AZNFSC_MAX_FILE_SIZE-trunc_len));
+
+    bytes_truncate += bytes_truncated;
+    bytes_truncate_g += bytes_truncated;
+
+    num_truncate++;
+    num_truncate_g++;
+
+    return bytes_truncated;
+}
+
+
 /*
  * TODO: Add pruning stats.
  */
@@ -1914,10 +2184,10 @@ void bytes_chunk_cache::inline_prune()
          * inode will be null only for testing.
          */
         assert(!inode || (inode->magic == NFS_INODE_MAGIC));
-        if (inode && inode->in_ra_window(mb->offset, mb->length)) {
+        if (inode && inode->in_ra_window(mb->offset.load(), mb->length.load())) {
             AZLogDebug("[{}] inline_prune(): skipping as membuf(offset={}, "
                        "length={}) lies in RA window",
-                       CACHE_TAG, mb->offset, mb->length);
+                       CACHE_TAG, mb->offset.load(), mb->length.load());
             inra++;
             inra_bytes += mb->allocated_length;
             continue;
@@ -1930,7 +2200,7 @@ void bytes_chunk_cache::inline_prune()
             AZLogDebug("[{}] inline_prune(): skipping as membuf(offset={}, "
                        "length={}) is inuse (locked={}, dirty={}, flushing={}, "
                        "uptodate={})",
-                       CACHE_TAG, mb->offset, mb->length,
+                       CACHE_TAG, mb->offset.load(), mb->length.load(),
                        mb->is_locked() ? "yes" : "no",
                        mb->is_dirty() ? "yes" : "no",
                        mb->is_flushing() ? "yes" : "no",
@@ -1950,7 +2220,7 @@ void bytes_chunk_cache::inline_prune()
             AZLogDebug("[{}] inline_prune(): skipping as membuf(offset={}, "
                        "length={}) is locked (dirty={}, flushing={}, "
                        "uptodate={})",
-                       CACHE_TAG, mb->offset, mb->length,
+                       CACHE_TAG, mb->offset.load(), mb->length.load(),
                        mb->is_dirty() ? "yes" : "no",
                        mb->is_flushing() ? "yes" : "no",
                        mb->is_uptodate() ? "yes" : "no");
@@ -1966,7 +2236,7 @@ void bytes_chunk_cache::inline_prune()
         if (mb->is_dirty()) {
             AZLogDebug("[{}] inline_prune(): skipping as membuf(offset={}, "
                        "length={}) is dirty (flushing={}, uptodate={})",
-                       CACHE_TAG, mb->offset, mb->length,
+                       CACHE_TAG, mb->offset.load(), mb->length.load(),
                        mb->is_flushing() ? "yes" : "no",
                        mb->is_uptodate() ? "yes" : "no");
             dirty++;
@@ -1981,7 +2251,7 @@ void bytes_chunk_cache::inline_prune()
         if (mb->is_commit_pending()) {
             AZLogDebug("[{}] inline_prune(): skipping as membuf(offset={}, "
                        "length={}) is commit_pending (dirty={} flushing={}, uptodate={})",
-                       CACHE_TAG, mb->offset, mb->length,
+                       CACHE_TAG, mb->offset.load(), mb->length.load(),
                        mb->is_dirty() ? "yes" : "no",
                        mb->is_flushing() ? "yes" : "no",
                        mb->is_uptodate() ? "yes" : "no");
@@ -1991,7 +2261,7 @@ void bytes_chunk_cache::inline_prune()
         }
 
         AZLogDebug("[{}] inline_prune(): deleting membuf(offset={}, length={})",
-                   CACHE_TAG, mb->offset, mb->length);
+                   CACHE_TAG, mb->offset.load(), mb->length.load());
 
         /*
          * Release the chunk.
@@ -2153,7 +2423,7 @@ void bytes_chunk_cache::clear_nolock(bool shutdown)
             if (mb->is_inuse()) {
                 AZLogDebug("[{}] Cache purge: skipping inuse membuf(offset={}, "
                            "length={}) (inuse count={}, dirty={})",
-                           CACHE_TAG, mb->offset, mb->length,
+                           CACHE_TAG, mb->offset.load(), mb->length.load(),
                            mb->get_inuse(), mb->is_dirty());
                 continue;
             }
@@ -2162,7 +2432,7 @@ void bytes_chunk_cache::clear_nolock(bool shutdown)
                 AZLogError("[{}] Cache purge: Got inuse membuf(offset={}, "
                            "length={}) (inuse count={}, dirty={}) when shutting "
                            "down cache",
-                           CACHE_TAG, mb->offset, mb->length,
+                           CACHE_TAG, mb->offset.load(), mb->length.load(),
                            mb->get_inuse(), mb->is_dirty());
                 // No membufs should be in use when file is closed.
                 assert(0);
@@ -2179,7 +2449,7 @@ void bytes_chunk_cache::clear_nolock(bool shutdown)
             if (mb->is_locked()) {
                 AZLogDebug("[{}] Cache purge: skipping locked membuf(offset={}, "
                            "length={}) (inuse count={}, dirty={})",
-                           CACHE_TAG, mb->offset, mb->length,
+                           CACHE_TAG, mb->offset.load(), mb->length.load(),
                            mb->get_inuse(), mb->is_dirty());
                 continue;
             }
@@ -2188,7 +2458,7 @@ void bytes_chunk_cache::clear_nolock(bool shutdown)
                 AZLogError("[{}] Cache purge: Got locked membuf(offset={}, "
                            "length={}) (inuse count={}, dirty={}) when shutting "
                            "down cache",
-                           CACHE_TAG, mb->offset, mb->length,
+                           CACHE_TAG, mb->offset.load(), mb->length.load(),
                            mb->get_inuse(), mb->is_dirty());
                 // No membufs should be locked when file is closed.
                 assert(0);
@@ -2203,7 +2473,7 @@ void bytes_chunk_cache::clear_nolock(bool shutdown)
             if (mb->is_dirty()) {
                 AZLogDebug("[{}] Cache purge: skipping dirty membuf(offset={}, "
                            "length={})",
-                           CACHE_TAG, mb->offset, mb->length);
+                           CACHE_TAG, mb->offset.load(), mb->length.load());
                 continue;
             }
         } else {
@@ -2215,7 +2485,7 @@ void bytes_chunk_cache::clear_nolock(bool shutdown)
                 AZLogWarn("[{}] Cache purge: Got dirty membuf(offset={}, "
                           "length={}) when shutting down cache, freeing it. "
                           "THIS MAY CAUSE FILE DATA TO BE INCONSISTENT!",
-                          CACHE_TAG, mb->offset, mb->length);
+                          CACHE_TAG, mb->offset.load(), mb->length.load());
             }
         }
 
@@ -2227,7 +2497,7 @@ void bytes_chunk_cache::clear_nolock(bool shutdown)
             if (mb->is_commit_pending()) {
                 AZLogDebug("[{}] Cache purge: skipping commit_pending "
                            "membuf(offset={}, length={})",
-                           CACHE_TAG, mb->offset, mb->length);
+                           CACHE_TAG, mb->offset.load(), mb->length.load());
                 continue;
             }
         } else {
@@ -2240,13 +2510,13 @@ void bytes_chunk_cache::clear_nolock(bool shutdown)
                           "membuf(offset={}, length={}) when shutting down "
                           "cache, freeing it. "
                           "THIS MAY CAUSE FILE DATA TO BE INCONSISTENT!",
-                          CACHE_TAG, mb->offset, mb->length);
+                          CACHE_TAG, mb->offset.load(), mb->length.load());
             }
         }
 
         AZLogDebug("[{}] Cache purge: deleting membuf(offset={}, length={}), "
                    "use_count={}, deleted {} of {}",
-                   CACHE_TAG, mb->offset, mb->length,
+                   CACHE_TAG, mb->offset.load(), mb->length.load(),
                    bc->get_membuf_usecount(),
                    start_size - chunkmap.size(), start_size);
 
@@ -2473,7 +2743,7 @@ static void cache_read(bytes_chunk_cache& cache,
 {
     std::vector<bytes_chunk> v;
 
-    AZLogVerbose("=====> cache_read({}, {})", offset, offset+length);
+    AZLogVerbose("=====> cache_read({}, {})", offset.load(), offset.load()+length.load());
     v = cache.get(offset, length);
     // At least one chunk.
     assert(v.size() >= 1);
@@ -2505,7 +2775,7 @@ static void cache_read(bytes_chunk_cache& cache,
     assert(total_length == length);
 
     AZLogVerbose("=====> cache_read({}, {}): vec={}",
-               offset, offset+length, v.size());
+               offset.load(), offset.load()+length.load(), v.size());
 }
 
 static void cache_write(bytes_chunk_cache& cache,
@@ -2515,7 +2785,7 @@ static void cache_write(bytes_chunk_cache& cache,
     std::vector<bytes_chunk> v;
     uint64_t l, r;
 
-    AZLogVerbose("=====> cache_write({}, {})", offset, offset+length);
+    AZLogVerbose("=====> cache_write({}, {})", offset.load(), offset.load()+length.load());
     v = cache.getx(offset, length, &l, &r);
     // At least one chunk.
     assert(v.size() >= 1);
@@ -2549,8 +2819,8 @@ static void cache_write(bytes_chunk_cache& cache,
     assert(total_length == length);
 
     AZLogVerbose("=====> cache_write({}, {}): l={} r={} vec={}",
-                 offset, offset+length, l, r, v.size());
-    AZLogVerbose("=====> cache_release({}, {})", offset, offset+length);
+                 offset.load(), offset.load()+length.load(), l, r, v.size());
+    AZLogVerbose("=====> cache_release({}, {})", offset.load(), offset.load()+length.load());
     assert(cache.release(offset, length) <= length);
 }
 

--- a/turbonfs/src/nfs_inode.cpp
+++ b/turbonfs/src/nfs_inode.cpp
@@ -925,9 +925,6 @@ int nfs_inode::wait_for_ongoing_flush(uint64_t start_off, uint64_t end_off)
                         get_write_error());
             }
 
-            mb->clear_locked();
-            mb->clear_inuse();
-
             /*
              * Release the bytes_chunk back to the filecache.
              * These bytes_chunks are not needed anymore as the flush is done.
@@ -941,6 +938,9 @@ int nfs_inode::wait_for_ongoing_flush(uint64_t start_off, uint64_t end_off)
              *       have released it, so we need to release it now.
              */
             filecache_handle->release(bc.offset, bc.length);
+
+            mb->clear_locked();
+            mb->clear_inuse();
         }
 
         // Re-grab flush_lock, now that the wait is over.
@@ -1059,9 +1059,6 @@ int nfs_inode::flush_cache_and_wait(uint64_t start_off, uint64_t end_off)
                        get_write_error());
         }
 
-        mb->clear_locked();
-        mb->clear_inuse();
-
         /*
          * Release the bytes_chunk back to the filecache.
          * These bytes_chunks are not needed anymore as the flush is done.
@@ -1075,6 +1072,9 @@ int nfs_inode::flush_cache_and_wait(uint64_t start_off, uint64_t end_off)
          *       released it, so we need to release it now.
          */
         filecache_handle->release(bc.offset, bc.length);
+
+        mb->clear_locked();
+        mb->clear_inuse();
     }
 
     /*

--- a/turbonfs/src/nfs_inode.cpp
+++ b/turbonfs/src/nfs_inode.cpp
@@ -851,10 +851,12 @@ int nfs_inode::wait_for_ongoing_flush(uint64_t start_off, uint64_t end_off)
      * flush_lock. We get the current flushing bcs atomically under flush_lock,
      * and then release the flush_lock while waiting. We repeat the same till
      * there are no flushing bcs. Technically we should not have back to back
-     * flushes started, but to be safe we try 10 times.
+     * flushes started, but to be safe we retry few times.
+     * In debug builds we can induce sleep in the write/flush callback, so we
+     * need to wait enough.
      */
     int retry, err = 0;
-    const int max_retry = 10;
+    const int max_retry = 200;
     for (retry = 0; retry < max_retry; retry++) {
         assert(is_flushing);
 

--- a/turbonfs/src/nfs_inode.cpp
+++ b/turbonfs/src/nfs_inode.cpp
@@ -520,9 +520,15 @@ void nfs_inode::sync_membufs(std::vector<bytes_chunk> &bc_vec,
          *       set_locked() call won't wait for write to complete.
          *       This is ensured because we only come here for membufs that are
          *       currently not flushing and hence cannot be waiting for a write.
+         *
+         * Note: bytes_chunk_cache::truncate() can truncate a membuf after we
+         *       get the list of dirty membufs and before we could get the lock
+         *       here, skip those.
          */
         mb->set_locked();
-        if (mb->is_flushing() || !mb->is_dirty()) {
+        if (mb->is_flushing() ||
+            !mb->is_dirty() ||
+            mb->is_truncated()) {
             mb->clear_locked();
             mb->clear_inuse();
 

--- a/turbonfs/src/nfs_inode.cpp
+++ b/turbonfs/src/nfs_inode.cpp
@@ -925,6 +925,9 @@ int nfs_inode::wait_for_ongoing_flush(uint64_t start_off, uint64_t end_off)
                         get_write_error());
             }
 
+            mb->clear_locked();
+            mb->clear_inuse();
+
             /*
              * Release the bytes_chunk back to the filecache.
              * These bytes_chunks are not needed anymore as the flush is done.
@@ -938,9 +941,6 @@ int nfs_inode::wait_for_ongoing_flush(uint64_t start_off, uint64_t end_off)
              *       have released it, so we need to release it now.
              */
             filecache_handle->release(bc.offset, bc.length);
-
-            mb->clear_locked();
-            mb->clear_inuse();
         }
 
         // Re-grab flush_lock, now that the wait is over.
@@ -1059,6 +1059,9 @@ int nfs_inode::flush_cache_and_wait(uint64_t start_off, uint64_t end_off)
                        get_write_error());
         }
 
+        mb->clear_locked();
+        mb->clear_inuse();
+
         /*
          * Release the bytes_chunk back to the filecache.
          * These bytes_chunks are not needed anymore as the flush is done.
@@ -1072,9 +1075,6 @@ int nfs_inode::flush_cache_and_wait(uint64_t start_off, uint64_t end_off)
          *       released it, so we need to release it now.
          */
         filecache_handle->release(bc.offset, bc.length);
-
-        mb->clear_locked();
-        mb->clear_inuse();
     }
 
     /*

--- a/turbonfs/src/rpc_task.cpp
+++ b/turbonfs/src/rpc_task.cpp
@@ -3224,13 +3224,6 @@ void rpc_task::run_read()
             // Check if the buffer got updated by the time we got the lock.
             if (bc_vec[i].get_membuf()->is_uptodate()) {
                 /*
-                * Release the lock since we no longer intend on writing
-                * to this buffer.
-                */
-                bc_vec[i].get_membuf()->clear_locked();
-                bc_vec[i].get_membuf()->clear_inuse();
-
-                /*
                  * Set "bytes read" to "bytes requested" since the data is read
                  * from the cache.
                  */
@@ -3250,6 +3243,14 @@ void rpc_task::run_read()
                  */
                 filecache_handle->release(bc_vec[i].offset, bc_vec[i].length);
 #endif
+
+                /*
+                 * Release the lock since we no longer intend on writing
+                 * to this buffer.
+                 */
+                bc_vec[i].get_membuf()->clear_locked();
+                bc_vec[i].get_membuf()->clear_inuse();
+
                 continue;
             }
 
@@ -3299,8 +3300,6 @@ void rpc_task::run_read()
             AZLogDebug("[{}] Data read from cache. offset: {}, length: {}",
                        ino, bc_vec[i].offset, bc_vec[i].length);
 
-            bc_vec[i].get_membuf()->clear_inuse();
-
             /*
              * Set "bytes read" to "bytes requested" since the data is read
              * from the cache.
@@ -3317,9 +3316,15 @@ void rpc_task::run_read()
              * Note that this is just a suggestion to release the buffer.
              * The buffer may not be released if it's in use by any other
              * user.
+             *
+             * Note: We have to grab the membuf lock here because release()
+             *       asserts for that.
              */
+            bc_vec[i].get_membuf()->set_locked();
             filecache_handle->release(bc_vec[i].offset, bc_vec[i].length);
+            bc_vec[i].get_membuf()->clear_locked();
 #endif
+            bc_vec[i].get_membuf()->clear_inuse();
         }
     }
 
@@ -3366,10 +3371,10 @@ void rpc_task::run_read()
 
 void rpc_task::send_read_response()
 {
-    [[maybe_unused]] const fuse_ino_t ino = rpc_api->read_task.get_ino();
-
     // This should always be called on the parent task.
     assert(rpc_api->parent_task == nullptr);
+
+    [[maybe_unused]] const fuse_ino_t ino = rpc_api->read_task.get_ino();
 
     /*
      * We must send response only after all component reads complete, they may
@@ -3729,17 +3734,9 @@ static void read_callback(
                 res->READ3res_u.resok.eof) {
                 assert(res->READ3res_u.resok.count < issued_length);
 
-                /*
-                 * We need to clear the inuse count held by this thread, else
-                 * release() will not be able to release. We drop and then
-                 * promptly grab the inuse count after the release(), so that
-                 * set_uptodate() can be called.
-                 */
-                bc->get_membuf()->clear_inuse();
                 const uint64_t released_bytes =
                     filecache_handle->release(bc->offset + bc->pvt,
                                               bc->length - bc->pvt);
-                bc->get_membuf()->set_inuse();
 
                 /*
                  * If we are able to successfully release all the extra bytes
@@ -3796,15 +3793,6 @@ static void read_callback(
                    errstr);
     }
 
-    /*
-    * Release the lock that we held on the membuf since the data is now
-    * written to it.
-    * The lock is needed only to write the data and not to just read it.
-    * Hence it is safe to read this membuf even beyond this point.
-    */
-    bc->get_membuf()->clear_locked();
-    bc->get_membuf()->clear_inuse();
-
 #ifdef RELEASE_CHUNK_AFTER_APPLICATION_READ
     /*
     * Since we come here only for client reads, we will not cache the data,
@@ -3813,6 +3801,15 @@ static void read_callback(
     */
     filecache_handle->release(bc->offset, bc->length);
 #endif
+
+    /*
+    * Release the lock that we held on the membuf since the data is now
+    * written to it.
+    * The lock is needed only to write the data and not to just read it.
+    * Hence it is safe to read this membuf even beyond this point.
+    */
+    bc->get_membuf()->clear_locked();
+    bc->get_membuf()->clear_inuse();
 
     // For failed status we must never mark the buffer uptodate.
     assert(!status || !bc->get_membuf()->is_uptodate());

--- a/turbonfs/src/rpc_task.cpp
+++ b/turbonfs/src/rpc_task.cpp
@@ -1490,6 +1490,7 @@ static void setattr_callback(
      * inode lock held by truncate_start().
      */
     if (valid & FUSE_SET_ATTR_SIZE) {
+        const struct stat *attr = task->rpc_api->setattr_task.get_attr();
         /*
          * Application can call truncate only on an open fd, hence when we come
          * here we must have the filecache allocated (refer on_fuse_open()), but
@@ -1498,7 +1499,7 @@ static void setattr_callback(
          * then calls FUSE_SETATTR on it without calling open().
          */
         if (inode->has_filecache()) {
-            inode->truncate_end();
+            inode->truncate_end(attr->st_size);
         } else {
             AZLogDebug("[{}] Filecache not present for truncate_end()", ino);
         }
@@ -3010,6 +3011,10 @@ void rpc_task::run_setattr()
             if (inode->has_filecache()) {
                 AZLogDebug("[{}]: Truncating file size to {}",
                            ino, attr->st_size);
+                /*
+                 * Note: This can block for a long time, as it waits for all
+                 *       ongoing IOs to finish.
+                 */
                 inode->truncate_start(attr->st_size);
             }
             
@@ -3072,7 +3077,7 @@ void rpc_task::run_setattr()
             if (valid & FUSE_SET_ATTR_SIZE) {
                 if (inode->has_filecache()) {
                     AZLogDebug("[{}]: Releasing flush_lock", ino);
-                    inode->truncate_end();
+                    inode->truncate_end(attr->st_size);
                 }
             }
 


### PR DESCRIPTION
This change gets rid of SCAN_ACTION_TRUNCATE and removes truncate support from bytes_chunk_cache::scan(). Now scan() cannot remove membufs which are in use or dirty. truncate() is a separate function now which specializes in truncating the cache and duly waits for locked bcs. It assumes that truncate will be called from contexts which can afford to wait and correctness is more important.