### PR TITLE
Try to balance libnfs rpc queues by not picking connections with qlen…

### DIFF
--- a/turbonfs/src/readahead.cpp
+++ b/turbonfs/src/readahead.cpp
@@ -26,7 +26,8 @@ ra_state::ra_state(struct nfs_client *_client,
         client(_client),
         inode(_inode),
         ra_bytes(client->mnt_options.readahead_kb * 1024),
-        def_ra_size(std::min<uint64_t>(client->mnt_options.rsize_adj, ra_bytes))
+        //def_ra_size(std::min<uint64_t>(client->mnt_options.rsize_adj, ra_bytes))
+        def_ra_size(std::min<uint64_t>(3 * 1024 * 1024, ra_bytes))
 {
     assert(client->magic == NFS_CLIENT_MAGIC);
     assert(inode->magic == NFS_INODE_MAGIC);

--- a/turbonfs/src/rpc_stats.cpp
+++ b/turbonfs/src/rpc_stats.cpp
@@ -152,6 +152,14 @@ void rpc_stats_az::dump_stats()
                   " RPC requests retransmitted\n";
     str += "  " + std::to_string(cum_stats.num_reconnects) +
                   " Reconnect attempts\n";
+    str += "  " + std::to_string(client.get_transport().get_avg_qlen_r()) +
+                  " Avg rpc qlen seen by reads\n";
+    str += "  " + std::to_string(client.get_transport().get_max_qlen_r()) +
+                  " Max rpc qlen seen by reads\n";
+    str += "  " + std::to_string(client.get_transport().get_avg_qlen_w()) +
+                  " Avg rpc qlen seen by writes\n";
+    str += "  " + std::to_string(client.get_transport().get_max_qlen_w()) +
+                  " Max rpc qlen seen by writes\n";
 
     str += "File/Inode statistics:\n";
     str += "  " + std::to_string(total_inodes) +


### PR DESCRIPTION
… > avg

This way we send requests to connections/nodes which are serving faster. It also helps balance load across CPU cores as high r/x traffic on few connections can cause some cpu cores to get choked.