### PR TITLE
Treat NFS3ERR_NOENT as success for retransmitted REMOVE and RMDIR RPCs

### DIFF
--- a/turbonfs/inc/aznfsc.h
+++ b/turbonfs/inc/aznfsc.h
@@ -322,6 +322,41 @@ typedef struct aznfsc_cfg
         // Max filecache size in GB.
         int max_size_gb = -1;
     } filecache;
+
+    /*************************************************
+     **           System related config             **
+     *************************************************/
+     struct {
+        /*
+         * Resolve server name before reconnect, else connect to the last
+         * resolved IP.
+         */
+        bool resolve_before_reconnect = true;
+
+        /*
+         * How should we behave when a retransmitted RPC fails possibly due to
+         * lack of federated DRC at the server.
+         */
+        struct {
+            /*
+             * REMOVE/RMDIR failing with NFS3ERR_NOENT must be treated as
+             * success.
+             */
+            bool remove_noent_as_success = true;
+
+            /*
+             * CREATE/MKNOD/MKDIR/SYMLINK failing with NFS3ERR_EXIST must be
+             * treated as success.
+             */
+            bool create_exist_as_success = true;
+
+            /*
+             * RENAME failing with NFS3ERR_NOENT must be treated as success.
+             */
+            bool rename_noent_as_success = true;
+        } nodrc;
+     } sys;
+
     /*
      * TODO:
      * - Add auth related config.

--- a/turbonfs/sample-turbo-config.yaml
+++ b/turbonfs/sample-turbo-config.yaml
@@ -29,8 +29,8 @@ acdirmin: 30
 acdirmax: 60
 actimeo: 300
 lookupcache: all
-rsize: 1048576
-wsize: 1048576
+rsize: 3145728
+wsize: 3145728
 
 #
 # Option controlling transport security, takes following values:
@@ -140,3 +140,11 @@ cache.data.user.max_size_mb: 16384
 #filecache.cachedir: /mnt
 #filecache.max_size_gb: 1000
 #cache_max_mb: 4096
+
+#
+# Config controlling misc system behaviour.
+#
+sys.resolve_before_reconnect: true
+sys.nodrc.remove_noent_as_success: true
+sys.nodrc.rename_noent_as_success: true
+sys.nodrc.create_exist_as_success: true

--- a/turbonfs/src/config.cpp
+++ b/turbonfs/src/config.cpp
@@ -162,6 +162,14 @@ do { \
             _CHECK_INT(filecache.max_size_gb, AZNFSCFG_FILECACHE_MAX_GB_MIN, AZNFSCFG_FILECACHE_MAX_GB_MAX);
         }
 
+        /*
+         * Config affecting misc system behaviour.
+         */
+        _CHECK_BOOL(sys.resolve_before_reconnect);
+        _CHECK_BOOL(sys.nodrc.remove_noent_as_success);
+        _CHECK_BOOL(sys.nodrc.create_exist_as_success);
+        _CHECK_BOOL(sys.nodrc.rename_noent_as_success);
+
     } catch (const YAML::BadFile& e) {
         AZLogError("Error loading config file {}: {}", config_yaml, e.what());
         return false;
@@ -356,6 +364,10 @@ void aznfsc_cfg::set_defaults_and_sanitize()
     AZLogDebug("filecache.enable = {}", filecache.enable);
     AZLogDebug("filecache.cachedir = {}", filecache.cachedir ? filecache.cachedir : "");
     AZLogDebug("filecache.max_size_gb = {}", filecache.max_size_gb);
+    AZLogDebug("sys.resolve_before_reconnect = {}", sys.resolve_before_reconnect);
+    AZLogDebug("sys.nodrc.remove_noent_as_success = {}", sys.nodrc.remove_noent_as_success);
+    AZLogDebug("sys.nodrc.create_exist_as_success = {}", sys.nodrc.create_exist_as_success);
+    AZLogDebug("sys.nodrc.rename_noent_as_success = {}", sys.nodrc.rename_noent_as_success);
     AZLogDebug("account = {}", account);
     AZLogDebug("container = {}", container);
     AZLogDebug("cloud_suffix = {}", cloud_suffix);

--- a/turbonfs/src/connection.cpp
+++ b/turbonfs/src/connection.cpp
@@ -148,7 +148,9 @@ bool nfs_connection::open()
      * LLAM may cause Blob NFS endpoint IP to change, direct libnfs to resolve
      * before reconnect.
      */
-    nfs_set_resolve_on_reconnect(nfs_context);
+    if (aznfsc_cfg.sys.resolve_before_reconnect) {
+        nfs_set_resolve_on_reconnect(nfs_context);
+    }
 
     /*
      * Call libnfs for mounting the share.


### PR DESCRIPTION
Support for other APIs is a TODO.